### PR TITLE
Update Netlify redirects to point to the SSR function instead of the …

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [[redirects]]
   from = "/*"
-  to = "/.netlify/functions/entry"
+  to = "/.netlify/functions/ssr"
   status = 200 


### PR DESCRIPTION
…entry function.